### PR TITLE
feat: update `style` prop to use `StyleProp` instead of `ViewStyle`

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { requireNativeComponent, ViewStyle } from 'react-native';
+import { requireNativeComponent, StyleProp, ViewStyle } from 'react-native';
 // @ts-ignore
 import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
 
 type TransparentVideoProps = {
-  style: ViewStyle;
+  style: StyleProp<ViewStyle>;
   source?: any;
   loop?: boolean;
 };


### PR DESCRIPTION
First off thank you very much for this package. It's been a big help!

The change I'm proposing is to be a little more flexible with how styles are passed in. React Native `View`s accept arrays of `ViewStyle`, so this change allows for that.

For example:

```jsx
<TransparentVideo source={mySource} style={[{ width: '100%' }, { height: '100%' }]} />
```

A bit of a contrived example, but I think this gets the point across.