### PR TITLE
Fixing android unattach bug

### DIFF
--- a/android/src/main/java/com/transparentvideo/AlphaMovieView.java
+++ b/android/src/main/java/com/transparentvideo/AlphaMovieView.java
@@ -427,12 +427,9 @@ public class AlphaMovieView extends GLTextureView {
         pause();
     }
 
-    @Override
-    protected void onDetachedFromWindow() {
-        super.onDetachedFromWindow();
+    protected void cleanup() {
         release();
-      handler.removeCallbacks(timeDetector);
-      TransparentVideoViewManager.destroyView((LinearLayout)this.getParent());
+        handler.removeCallbacks(timeDetector);
     }
 
     private void prepareAsync(final MediaPlayer.OnPreparedListener onPreparedListener) {

--- a/android/src/main/java/com/transparentvideo/TransparentVideoViewManager.java
+++ b/android/src/main/java/com/transparentvideo/TransparentVideoViewManager.java
@@ -22,8 +22,6 @@ import java.util.List;
 
 public class TransparentVideoViewManager extends SimpleViewManager<LinearLayout> {
 
-  private static List<LinearLayout> sInstances = new ArrayList<>();
-
   public static final String REACT_CLASS = "TransparentVideoView";
   private static final String TAG = "TransparentVideoViewManager";
 
@@ -43,7 +41,6 @@ public class TransparentVideoViewManager extends SimpleViewManager<LinearLayout>
   @NonNull
   public LinearLayout createViewInstance(ThemedReactContext reactContext) {
     LinearLayout view = new LinearLayout(this.reactContext);
-    sInstances.add(view);
     return view;
   }
 

--- a/android/src/main/java/com/transparentvideo/TransparentVideoViewManager.java
+++ b/android/src/main/java/com/transparentvideo/TransparentVideoViewManager.java
@@ -47,8 +47,11 @@ public class TransparentVideoViewManager extends SimpleViewManager<LinearLayout>
     return view;
   }
 
-  public static void destroyView(LinearLayout view) {
-    sInstances.remove(view);
+  @Override
+  public void onDropViewInstance(@NonNull LinearLayout view) {
+    super.onDropViewInstance(view);
+    AlphaMovieView alphaMovieView = (AlphaMovieView)view.getChildAt(0);
+    alphaMovieView.cleanup();
   }
 
   @ReactProp(name = "src")


### PR DESCRIPTION
There is a bug with the current implementation - if the user navigates away from the page, the video is removed. When the user navigates back and a new element is not created, there is no longer anything playing.

I'm moving instead to another lifecycle method, onDropViewInstance for everything cleanup related. This way the video is not removed if the element is not removed.

Also removing sInstances from the view manager because as far as i can tell it's not doing anything. 